### PR TITLE
Generic Types - Force Custom values - Consider last sequence value

### DIFF
--- a/src/main/java/randoop/generation/AbstractGenerator.java
+++ b/src/main/java/randoop/generation/AbstractGenerator.java
@@ -458,18 +458,20 @@ public abstract class AbstractGenerator {
    * @param sequence sequence for build the object
    */
   private void buildAndSaveNewObject(ExecutableSequence sequence){
-    Variable var = loadCUTVars(this.objectsClass, sequence);
-    if (var != null) {
+    List<Variable> vars = loadCUTVars(this.objectsClass, sequence);
+    if (!vars.isEmpty()) {
       //Check if the sequence has an exception
       if(sequence.isNormalExecution() && !sequence.hasFailure() && !sequence.hasInvalidBehavior()) {
-        Object newObject = ExecutableSequence.getRuntimeValuesForVars(
-                Collections.singletonList(var), sequence.executionResults)[0];
-        if (!this.allObjects.contains(newObject)) {
-          this.allObjects.add(newObject);
-          if(this.assume.apply(newObject)) {
-            this.objectsAmount++;
-            this.lastObject = newObject;
-            this.lastSeq = sequence.sequence;
+        for (Variable var : vars) {
+          Object newObject = ExecutableSequence.getRuntimeValuesForVars(
+                  Collections.singletonList(var), sequence.executionResults)[0];
+          if (!this.allObjects.contains(newObject)) {
+            this.allObjects.add(newObject);
+            if (this.assume.apply(newObject)) {
+              this.objectsAmount++;
+              this.lastObject = newObject;
+              this.lastSeq = sequence.sequence;
+            }
           }
         }
       }

--- a/src/main/java/randoop/generation/ComponentManager.java
+++ b/src/main/java/randoop/generation/ComponentManager.java
@@ -1,9 +1,7 @@
 package randoop.generation;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.*;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 import randoop.main.RandoopBug;
 import randoop.operation.TypedClassOperation;
@@ -77,6 +75,8 @@ public class ComponentManager {
    */
   private @Nullable PackageLiterals packageLiterals = null;
 
+  private BitSet customValuesFor = new BitSet(3);
+
   /** Create an empty component manager, with an empty seed sequence set. */
   public ComponentManager() {
     gralComponents = new SequenceCollection();
@@ -141,6 +141,18 @@ public class ComponentManager {
    * @param sequence the sequence
    */
   public void addGeneratedSequence(Sequence sequence) {
+    if (!sequence.allVariablesForTypeLastStatement(Type.forClass(int.class), false).isEmpty()
+        && customValuesFor.get(CustomValues.INTEGER.ordinal())) {
+      return;
+    }
+    if (!sequence.allVariablesForTypeLastStatement(Type.forClass(double.class), false).isEmpty()
+            && customValuesFor.get(CustomValues.DOUBLE.ordinal())) {
+      return;
+    }
+    if (!sequence.allVariablesForTypeLastStatement(Type.forClass(String.class), false).isEmpty()
+            && customValuesFor.get(CustomValues.STRING.ordinal())) {
+      return;
+    }
     gralComponents.add(sequence);
   }
 
@@ -273,4 +285,9 @@ public class ComponentManager {
     }
     gralComponents.log();
   }
+
+  public void usingCustomValuesFor(CustomValues t) {
+    customValuesFor.set(t.ordinal());
+  }
+
 }

--- a/src/main/java/randoop/generation/CustomValues.java
+++ b/src/main/java/randoop/generation/CustomValues.java
@@ -1,0 +1,7 @@
+package randoop.generation;
+
+public enum CustomValues {
+    INTEGER,
+    DOUBLE,
+    STRING,
+}

--- a/src/main/java/randoop/generation/ForwardGenerator.java
+++ b/src/main/java/randoop/generation/ForwardGenerator.java
@@ -5,6 +5,8 @@ import static randoop.main.GenInputsAbstract.findAssignableClass;
 
 import java.lang.reflect.Modifier;
 import java.util.*;
+import java.util.stream.Collectors;
+
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.plumelib.util.CollectionsPlume;
 import org.plumelib.util.StringsPlume;
@@ -910,6 +912,8 @@ public class ForwardGenerator extends AbstractGenerator {
     if (rog == null) {
       return null;
     }
+    rog.setCustomSeed(this.componentManager.getAllGeneratedSequences());
+    rog.setCustomSeed(this.componentManager.getAllPrimitiveSequences());
     rog.generate();
     return rog.getLastSequence();
   }

--- a/src/main/java/randoop/generation/ForwardGenerator.java
+++ b/src/main/java/randoop/generation/ForwardGenerator.java
@@ -116,7 +116,7 @@ public class ForwardGenerator extends AbstractGenerator {
       IStopper stopper,
       Set<ClassOrInterfaceType> classesUnderTest,
       Class<?> objectsClass,
-      Map<TypeVariable, Class<?>> parameterizedClass) {
+      Map<Class<?>, Map<TypeVariable, Class<?>>> parameterizedClass) {
     this(
         operations,
         sideEffectFreeMethods,

--- a/src/main/java/randoop/main/GenTests.java
+++ b/src/main/java/randoop/main/GenTests.java
@@ -541,16 +541,6 @@ public class GenTests extends GenInputsAbstract {
 
       List<ExecutableSequence> regressionSequences = explorer.getRegressionSequences();
 
-      List<Stack<Object>> values = new ArrayList<>();
-      for(ExecutableSequence e: regressionSequences){
-        Variable var = loadCUTVars(Stack.class, e);
-        if(var != null) {
-          values.add((Stack)ExecutableSequence.getRuntimeValuesForVars(Collections.singletonList(var), e.executionResults)[0]);
-        }
-      }
-      System.out.println(Arrays.toString(values.stream().filter(o -> !o.isEmpty()).toArray()));
-
-
       if (GenInputsAbstract.progressdisplay) {
         System.out.printf(
                 "%nAbout to look for failing assertions in %d regression sequences.%n",
@@ -598,18 +588,19 @@ public class GenTests extends GenInputsAbstract {
     return true;
   }
 
-  public static Variable loadCUTVars(Class<?> cut, ExecutableSequence seq) {
+  public static List<Variable> loadCUTVars(Class<?> cut, ExecutableSequence seq) {
     seq.execute(new DummyVisitor(), new DummyCheckGenerator());
+    List<Variable> vars = new ArrayList<>();
     for (ReferenceValue referenceValue : seq.getAllValues()) {
       if (referenceValue.getType().getCanonicalName().equals(cut.getName())) {
-        return seq.getVariable(referenceValue.getObjectValue());
+        vars.add(seq.getVariable(referenceValue.getObjectValue()));
       }
 //      else if(cut.isAssignableFrom(referenceValue.getType().getRuntimeClass())){
 //        //TODO: cambiar aca
 //        return seq.getVariable(referenceValue.getObjectValue());
 //      }
     }
-    return null;
+    return vars;
   }
   /**
    * Read side-effect-free methods from the default JDK side-effect-free method list, and from a

--- a/src/main/java/randoop/main/RandoopObjectGenerator.java
+++ b/src/main/java/randoop/main/RandoopObjectGenerator.java
@@ -46,7 +46,7 @@ public class RandoopObjectGenerator extends GenTests {
   private final Class<?> objectClass;
 
   /** Map the type variable (T, Q) of @objectClass with the parameterization */
-  private Map<TypeVariable, Class<?>> parameterizedClasses = new HashMap<>();
+  private Map<Class<?>, Map<TypeVariable, Class<?>>> parameterizedClasses = new HashMap<>();
 
   /** Object generator */
   private AbstractGenerator explorer;
@@ -112,14 +112,16 @@ public class RandoopObjectGenerator extends GenTests {
   public RandoopObjectGenerator(Class<?> objectClass, List<Class<?>> typeArguments, int seed) {
     this(objectClass, seed);
     List<TypeVariable> s = ClassOrInterfaceType.forClass(objectClass).getTypeParameters();
-    if (s.size() < typeArguments.size())
+    if (s.size() != typeArguments.size())
       throw new IllegalArgumentException(
-          "More parameterized types than parameters"); // Note: No se como describirlo!!!!!
+          "Expected " + typeArguments.size() + " type parameters but " + s.size() + " was/were found");
+    Map<TypeVariable, Class<?>> typeVariableToClass = new HashMap<>();
     for (Class<?> c : typeArguments) {
-      this.parameterizedClasses.put(s.remove(0), c);
+      typeVariableToClass.put(s.remove(0), c);
       if (!c.equals(Integer.class) && !c.equals(String.class) && !c.equals(Double.class))
         classesGenerators.put(c, new RandoopObjectGenerator(c, seed));
     }
+    this.parameterizedClasses.put(objectClass, typeVariableToClass);
   }
 
   /**

--- a/src/main/java/randoop/main/RandoopObjectGenerator.java
+++ b/src/main/java/randoop/main/RandoopObjectGenerator.java
@@ -69,6 +69,8 @@ public class RandoopObjectGenerator extends GenTests {
   /** Regex of methods for generate secuencees */
   private Pattern methodsToUse = null;
 
+  private Set<Sequence> customSeed = new HashSet<>();
+
   /**
    * Constructs a RandoopObjectGenerator for a given class.
    *
@@ -499,13 +501,29 @@ public class RandoopObjectGenerator extends GenTests {
      *   <li>Add any values for TestValue annotated static fields in operationModel
      * </ul>
      */
-    Set<Sequence> defaultSeeds = SeedSequences.defaultSeeds();
+    Set<Sequence> defaultSeeds = new HashSet<>();
+    if (customSeed.isEmpty()) {
+      defaultSeeds.addAll(SeedSequences.defaultSeeds());
+    } else {
+      defaultSeeds.addAll(customSeed);
+    }
     Set<Sequence> annotatedTestValues = operationModel.getAnnotatedTestValues();
     Set<Sequence> components =
         new LinkedHashSet<>(
             CollectionsPlume.mapCapacity(defaultSeeds.size() + annotatedTestValues.size()));
     components.addAll(defaultSeeds);
     components.addAll(annotatedTestValues);
+
+    // FIXME: The idea is to remove the default values if the user use its own custom ones.
+    if (!customIntegers.isEmpty()) {
+      components.removeIf((s) -> !s.allVariablesForTypeLastStatement(Type.forClass(int.class), false).isEmpty());
+    }
+    if (!customDoubles.isEmpty()) { // TODO: Maybe this can affect floats, indeed, above integers could affect longs.
+      components.removeIf((s) -> !s.allVariablesForTypeLastStatement(Type.forClass(double.class), false).isEmpty());
+    }
+    if (!customStrings.isEmpty()) {
+      components.removeIf((s) -> !s.allVariablesForTypeLastStatement(Type.forClass(String.class), false).isEmpty());
+    }
 
     ComponentManager componentMgr = new ComponentManager(components);
     operationModel.addClassLiterals(
@@ -628,6 +646,16 @@ public class RandoopObjectGenerator extends GenTests {
 
     addCustomIntegersToExplorer();
     addCustomStringsToExplorer();
+
+    if (!customIntegers.isEmpty()) {
+      componentMgr.usingCustomValuesFor(CustomValues.INTEGER);
+    }
+    if (!customDoubles.isEmpty()) {
+      componentMgr.usingCustomValuesFor(CustomValues.DOUBLE);
+    }
+    if (!customStrings.isEmpty()) {
+      componentMgr.usingCustomValuesFor(CustomValues.STRING);
+    }
     if (this.assume != null) {
       explorer.setAssume(this.assume);
     }
@@ -664,4 +692,9 @@ public class RandoopObjectGenerator extends GenTests {
   public Sequence getLastSequence() {
     return explorer.getLastSequence();
   }
+
+  public void setCustomSeed(Set<Sequence> allSequences) {
+    customSeed.addAll(allSequences);
+  }
+
 }

--- a/src/main/java/randoop/reflection/TypeInstantiator.java
+++ b/src/main/java/randoop/reflection/TypeInstantiator.java
@@ -3,6 +3,8 @@ package randoop.reflection;
 import static org.plumelib.util.CollectionsPlume.iteratorToIterable;
 
 import java.util.*;
+import java.util.stream.Collectors;
+
 import org.plumelib.util.CombinationIterator;
 import randoop.operation.TypedClassOperation;
 import randoop.types.BoundsCheck;
@@ -37,7 +39,7 @@ public class TypeInstantiator {
   private final Set<Type> inputTypes;
 
   /** The class of parameterized type for this model. */
-  private Map<TypeVariable, Class<?>> parameterizedClass;
+  private Map<Class<?>, Map<TypeVariable, Class<?>>> parameterizedClasses;
 
   /**
    * Creates a {@link TypeInstantiator} object using the given types to construct instantiating
@@ -48,7 +50,7 @@ public class TypeInstantiator {
   public TypeInstantiator(Set<Type> inputTypes) {
     // No defensive copy:  the value changes with time, but this class doesn't change it.
     this.inputTypes = inputTypes;
-    this.parameterizedClass = new HashMap<>();
+    this.parameterizedClasses = new HashMap<>();
   }
 
   /**
@@ -57,16 +59,17 @@ public class TypeInstantiator {
    *
    * @param inputTypes the ground types for instantiations
    */
-  public TypeInstantiator(Set<Type> inputTypes, Map<TypeVariable, Class<?>> parameterizedClass) {
+  public TypeInstantiator(Set<Type> inputTypes, Map<Class<?>, Map<TypeVariable, Class<?>>> parameterizedClasses) {
     // No defensive copy:  the value changes with time, but this class doesn't change it.
     this.inputTypes = inputTypes;
-    this.parameterizedClass = parameterizedClass;
+    this.parameterizedClasses = parameterizedClasses;
   }
 
-  public void setParameterizedClass(Map<TypeVariable, Class<?>> parameterizedClass) {
-    this.parameterizedClass.putAll(parameterizedClass);
-    for (Class<?> c : parameterizedClass.values()) {
-      this.inputTypes.add(Type.forClass(c));
+  public void setParameterizedClass(Map<Class<?>, Map<TypeVariable, Class<?>>> parameterizedClasses) {
+    this.parameterizedClasses.putAll(parameterizedClasses);
+    this.inputTypes.addAll(parameterizedClasses.keySet().stream().map(Type::forClass).collect(Collectors.toList()));
+    for (Map<TypeVariable, Class<?>> map : parameterizedClasses.values()) {
+      this.inputTypes.addAll(map.values().stream().map(Type::forClass).collect(Collectors.toList()));
     }
   }
 
@@ -198,6 +201,10 @@ public class TypeInstantiator {
    * @return a substitution instantiating the given type; null if none is found
    */
   private Substitution instantiateClass(ClassOrInterfaceType type) {
+    if (parameterizedClasses.containsKey(type.getRuntimeClass())) {
+      return getSubstitutionForSelectedTypes(type);
+    }
+
     boolean tryPrevious = Randomness.weightedCoinFlip(0.5);
 
     if (tryPrevious) {
@@ -231,6 +238,15 @@ public class TypeInstantiator {
     }
 
     return null;
+  }
+
+  private Substitution getSubstitutionForSelectedTypes(ClassOrInterfaceType type) {
+    assert type.getTypeParameters().size() == parameterizedClasses.get(type.getRuntimeClass()).size();
+    List<ReferenceType> types = new ArrayList<>();
+    for (TypeVariable typeVariable : type.getTypeParameters()) {
+      types.add(ReferenceType.forClass(parameterizedClasses.get(type.getRuntimeClass()).get(typeVariable)));
+    }
+    return new Substitution(type.getTypeParameters(), types);
   }
 
   /**
@@ -467,11 +483,13 @@ public class TypeInstantiator {
   private Substitution selectSubstitutionIndependently(
       List<TypeVariable> parameters, Substitution substitution) {
     List<ReferenceType> selectedTypes = new ArrayList<>(parameters.size());
-
+    // FIXME: ola, aca no se cuando entramos, no me cierra, quizas es lo que quiero hacer, pero me parece mas sencilla
+    //  mi idea de leer el map simplemente y ya.
     for (TypeVariable typeArgument : parameters) {
       List<ReferenceType> candidates = candidateTypes(typeArgument);
+      Class<?> cut = Object.class;
       // NotE: hay que preguntar si esta la clase que queremos instanciar y esto lo retorna
-      Class<?> clazz = parameterizedClass.get(typeArgument);
+      Class<?> clazz = parameterizedClasses.get(cut).get(typeArgument);
       Optional<ReferenceType> lookingType = Optional.empty();
       if (clazz != null)
         lookingType =

--- a/src/main/java/randoop/sequence/ExecutableSequence.java
+++ b/src/main/java/randoop/sequence/ExecutableSequence.java
@@ -516,7 +516,7 @@ public class ExecutableSequence {
    */
   public List<ReferenceValue> getAllValues() {
     Set<ReferenceValue> values = new LinkedHashSet<>();
-    for (int i = 0; i < sequence.size() - 1; i++) {
+    for (int i = 0; i < sequence.size(); i++) {
       try {
         Object value = getValue(i);
         if (value != null) {

--- a/src/main/java/randoop/sequence/SequenceCollection.java
+++ b/src/main/java/randoop/sequence/SequenceCollection.java
@@ -155,6 +155,10 @@ public class SequenceCollection {
               + " should be assignable from "
               + argument.getType().getBinaryName();
       if (sequence.isActive(argument.getDeclIndex())) {
+        // FIXME: I add this remove line because if you have because if we same something like Cut<K>
+        //  and in the new sequence you instantiate K with some class C then the set is not updated, and it should
+        //  i think...
+        typesAndSupertypes.remove(formalType);
         typesAndSupertypes.add(formalType);
         if (formalType.isClassOrInterfaceType()) {
           // This adds all the supertypes, not just immediate ones.

--- a/src/main/java/randoop/types/PrimitiveTypes.java
+++ b/src/main/java/randoop/types/PrimitiveTypes.java
@@ -119,7 +119,9 @@ public final class PrimitiveTypes {
     }
 
     // check identity and primitive  widening
-    return source.equals(target) || isSubtype(source, target);
+    // return source.equals(target) || isSubtype(source, target);
+    // FIXME: The above line is the original, the idea is: for primitive types, the match should be exact
+    return source.equals(target);
   }
 
   /**


### PR DESCRIPTION
I forget to merge this earlier. So, now you can set generic types of the generic classes. 
The custom values now are forced to be used, and new values generated during the sequences generation are not considered for those types. 
The method getAllValues did not consider the last statement of the sequence.